### PR TITLE
Use atlasName instead of name as cohortName

### DIFF
--- a/R/RunStudy.R
+++ b/R/RunStudy.R
@@ -495,7 +495,7 @@ loadCohortsFromPackage <- function(cohortIds) {
     cohorts <- cohorts[cohorts$cohortId %in% cohortIds, ]
   }
   if ("atlasName" %in% colnames(cohorts)) {
-    cohorts <- dplyr::rename(cohorts, cohortName = "name", cohortFullName = "name")
+    cohorts <- dplyr::rename(cohorts, cohortName = "atlasName", cohortFullName = "atlasName")
   } else {
     cohorts <- dplyr::rename(cohorts, cohortName = "name", cohortFullName = "fullName")
   }
@@ -520,7 +520,7 @@ loadCohortsForExportFromPackage <- function(cohortIds) {
   cohorts <- getCohortsToCreate()
   cohorts$atlasId <- NULL
   if ("atlasName" %in% colnames(cohorts)) {
-    cohorts <- dplyr::rename(cohorts, cohortName = "name", cohortFullName = "atlasName")
+    cohorts <- dplyr::rename(cohorts, cohortName = "atlasName", cohortFullName = "atlasName")
   } else {
     cohorts <- dplyr::rename(cohorts, cohortName = "name", cohortFullName = "fullName")
   }

--- a/inst/shiny/PioneerWatchfulWaitingExplorer/cohorts.csv
+++ b/inst/shiny/PioneerWatchfulWaitingExplorer/cohorts.csv
@@ -1,1 +1,66 @@
-cohortId,name,atlasId,circeDef
+﻿cohortId, name, atlasID, circeDef
+101, [PIONEER T1] Newly diagnosed Pca, 47, TRUE
+103, [PIONEER T2] PCa treated right away, 49, TRUE
+111,[PIONEER T3] PCa under conservative management,137,TRUE
+117,[PIONEER T4] PCa treated after conservative management ,143,TRUE
+105,[PIONEER T3.1] PCa high/intermediate risk conservative management,138,TRUE
+107,[PIONEER T3.2] PCa low risk grade conservative management and no intense monitoring,139,TRUE
+109,[PIONEER T3.3] PCa low risk grade conservative management and intense monitoring,140,TRUE
+113,[PIONEER T4.1] Delayed Curative Management,144,TRUE
+115,[PIONEER T4.2] Delayed Palliative Management,145,TRUE
+102,[PIONEER T1a] Newly diagnosed Pca_broad,141,TRUE
+104,[PIONEER T2a] PCa treated right away_broad,142,TRUE
+112,[PIONEER T3a] PCa under conservative management_broad,125,TRUE
+118,[PIONEER T4a] PCa treated after conservative management_broad,129,TRUE
+106,[PIONEER T3.1a] PCa high/intermediate risk conservative managemetn_broad,126,TRUE
+108,[PIONEER T3.2a] PCa low risk grade conservative management and no intense monitoring_broad,127,TRUE
+110,[PIONEER T3.3a] PCa low risk grade conservative management and intense monitoring_broad,128,TRUE
+114,[PIONEER T4.1a] Delayed Curative Management_broad,131,TRUE
+116,[PIONEER T4.2a] Delayed Palliative Management_broad,132,TRUE
+119,[PIONEER T5] Symptom post conservative management ,168,TRUE
+120,[PIONEER T5a] Symptom post conservative management_broad,167,TRUE
+202,[PIONEER O1] Death,46,TRUE
+201,[PIONEER O2] Symptomatic progression ,45,TRUE
+203,[PIONEER O3] Treatment initiation,61,TRUE
+204,[PIONEER O4] Curative treatment,73,TRUE
+205,[PIONEER O5] Palliative treatment ,74,TRUE
+206,[PIONEER O6] Hospitalization,87,TRUE
+207,[PIONEER O7 ] ED visit,90,TRUE
+301,[PIONEER S1] EAU High Risk,52,TRUE
+302,[PIONEER S2] EAU Low Risk,53,TRUE
+303,[PIONEER S3] EAU Intermediate Risk,54,TRUE
+304,[PIONEER S4] Metastatic PCa,55,TRUE
+305,[PIONEER S5] Locally Advanced PCa,56,TRUE
+306,[PIONEER S6] localized PCa,57,TRUE
+307,[PIONEER S7] PSA >20 at Diagnosis ,58,TRUE
+308,[PIONEER S8] PSA <10 at Diagnosis,59,TRUE
+309,[PIONEER S9] PSA 10-20 at Diagnosis,60,TRUE
+310,[PIONEER S10] Stage cT1 at Dx,63,TRUE
+311,[PIONEER S11] Stage cT2 at Dx,64,TRUE
+312,[PIONEER S12] Stage cT3/cT4 at Dx,65,TRUE
+313,[PIONEER S13] Physical Therapy/Exercise,112,TRUE
+314,[PIONEER S14] Grade 1 (GS 2-6),67,TRUE
+315,[PIONEER S15] Grade 2 (GS 3+4),68,TRUE
+316,[PIONEER S16] Grade 3 (GS 4+3),69,TRUE
+317,[PIONEER S17] Grade 4 (GS 8),70,TRUE
+318,[PIONEER S18] Grade 5 (GS 9-10),71,TRUE
+319,[PIONEER S19] Family history of Prostate cancer or history of family history of germline mutations,72,TRUE
+320,[PIONEER S20] Mutation (germline or somatic) in BRCA2, BRCA1, ATM, MLH1, MSH1, MSH2, MSH6, CHEK2, RAD51B and PALB2 ,83,TRUE
+321,[PIONEER S21] Age at diagnosis <55,111,TRUE
+322,[PIONEER S22] Age at diagnosis 55-80,110,TRUE
+323,[PIONEER S23] Age at diagnosis >80,109,TRUE
+324,[PIONEER S24] Charlson CCI=0,120,TRUE
+325,[PIONEER S25] Charlson CCI=1,121,TRUE
+326,[PIONEER S26] Charlson CCI>=2,122,TRUE
+327,[PIONEER S27] Any malignancy, except malignant neoplasm of skin,81,TRUE
+334,[PIONEER S28] Performance status ECOG=0,164,TRUE
+335,[PIONEER S29] Performance status ECOG=1,165,TRUE
+336,[PIONEER S30] Performance status ECOG=2+,166,TRUE
+328,[PIONEER S31] Total Cardiovascular Disease Event,152,TRUE
+329,[PIONEER S32] Stroke,153,TRUE
+330,[PIONEER S33] Type 2 Diabetes,154,TRUE
+331,[PIONEER S34] Hypertension,155,TRUE
+332,[PIONEER S35] Obesity,156,TRUE
+333,[PIONEER S36] VTE,157,TRUE
+337,[PIONEER S37] Anxiety,158,TRUE
+338,[PIONEER S38] Prevalent Asthma or Chronic obstructive pulmonary disease (COPD),159,TRUE

--- a/inst/shiny/PioneerWatchfulWaitingExplorer/cohorts.csv
+++ b/inst/shiny/PioneerWatchfulWaitingExplorer/cohorts.csv
@@ -1,6 +1,6 @@
-﻿cohortId, name, atlasID, circeDef
-101, [PIONEER T1] Newly diagnosed Pca, 47, TRUE
-103, [PIONEER T2] PCa treated right away, 49, TRUE
+cohortId, name, atlasID, circeDef
+101,[PIONEER T1] Newly diagnosed Pca, 47, TRUE
+103,[PIONEER T2] PCa treated right away, 49, TRUE
 111,[PIONEER T3] PCa under conservative management,137,TRUE
 117,[PIONEER T4] PCa treated after conservative management ,143,TRUE
 105,[PIONEER T3.1] PCa high/intermediate risk conservative management,138,TRUE
@@ -45,14 +45,14 @@
 317,[PIONEER S17] Grade 4 (GS 8),70,TRUE
 318,[PIONEER S18] Grade 5 (GS 9-10),71,TRUE
 319,[PIONEER S19] Family history of Prostate cancer or history of family history of germline mutations,72,TRUE
-320,[PIONEER S20] Mutation (germline or somatic) in BRCA2, BRCA1, ATM, MLH1, MSH1, MSH2, MSH6, CHEK2, RAD51B and PALB2 ,83,TRUE
+320,"[PIONEER S20] Mutation (germline or somatic) in BRCA2, BRCA1, ATM, MLH1, MSH1, MSH2, MSH6, CHEK2, RAD51B and PALB2 ",83,TRUE
 321,[PIONEER S21] Age at diagnosis <55,111,TRUE
 322,[PIONEER S22] Age at diagnosis 55-80,110,TRUE
 323,[PIONEER S23] Age at diagnosis >80,109,TRUE
 324,[PIONEER S24] Charlson CCI=0,120,TRUE
 325,[PIONEER S25] Charlson CCI=1,121,TRUE
 326,[PIONEER S26] Charlson CCI>=2,122,TRUE
-327,[PIONEER S27] Any malignancy, except malignant neoplasm of skin,81,TRUE
+327,"[PIONEER S27] Any malignancy, except malignant neoplasm of skin",81,TRUE
 334,[PIONEER S28] Performance status ECOG=0,164,TRUE
 335,[PIONEER S29] Performance status ECOG=1,165,TRUE
 336,[PIONEER S30] Performance status ECOG=2+,166,TRUE

--- a/inst/shiny/PioneerWatchfulWaitingExplorer/cohorts.csv
+++ b/inst/shiny/PioneerWatchfulWaitingExplorer/cohorts.csv
@@ -25,7 +25,10 @@ cohortId, name, atlasID, circeDef
 204,[PIONEER O4] Curative treatment,73,TRUE
 205,[PIONEER O5] Palliative treatment ,74,TRUE
 206,[PIONEER O6] Hospitalization,87,TRUE
-207,[PIONEER O7 ] ED visit,90,TRUE
+207,[PIONEER O7] ED visit,90,TRUE
+208,[PIONEER O10] RP (Radical Prostatectomy),,
+209,[PIONEER ON2] ADT,,
+210,[PIONEER O12] RP (Radical Prostatectomy),,
 301,[PIONEER S1] EAU High Risk,52,TRUE
 302,[PIONEER S2] EAU Low Risk,53,TRUE
 303,[PIONEER S3] EAU Intermediate Risk,54,TRUE

--- a/inst/shiny/PioneerWatchfulWaitingExplorer/global.R
+++ b/inst/shiny/PioneerWatchfulWaitingExplorer/global.R
@@ -116,6 +116,24 @@ if (dataStorage == "database") {
 
 if (exists("covariate")) {
   covariate <- unique(covariate)
+  covNameWithId <- grepl(': \\d\\d\\d$', covariate$covariateName)
+  if (any(covNameWithId)) {
+    # Temporary quick fix to replace cohortId with atlasName
+    cohorts <- readr::read_csv("./cohorts.csv", col_types = readr::cols())
+    newCovariateName <- sapply(covariate$covariateName[covNameWithId],
+                       function(x) {
+                         cohortId <- substr(x, nchar(x)-2, nchar(x))
+                         cohort <- cohorts[cohorts$cohortId==cohortId,]
+                         if (nrow(cohort) > 0) {
+                           return(paste0(substr(x, 1, nchar(x)-3), cohort$name))
+                         } else {
+                           # cohortId not found, return original
+                           return(x)
+                         }
+                       }
+   )
+   covariate$covariateName[covNameWithId] <- newCovariateName
+  }
   covariate$windowId <- as.numeric(substr(covariate$covariateId, nchar(covariate$covariateId), nchar(covariate$covariateId)))
 }
 


### PR DESCRIPTION
This PR is both a fix for adding in the results the full name of the cohort instead of an id, and displaying old results with the full name. 
Fixes #39