### PR TITLE
Bumps for release 0.4.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: PioneerWatchfulWaiting
 Type: Package
 Title: PIONEER / EHDEN / OHDSI prostate cancer study
-Version: 0.3.2
+Version: 0.4.0
 Author: Anthony G. Sena, Artem Gorbachev, Kees van Bochove
 Authors@R: c(
     person("Anthony G.", "Sena", email = "asena5@its.jnj.com", role = c("aut")),

--- a/R/Sharing.R
+++ b/R/Sharing.R
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 rootFTPFolder <- function() {
-  return("/Task4/")
+  return("/Task5/")
 }
 
 #' @export

--- a/codemeta.json
+++ b/codemeta.json
@@ -10,7 +10,7 @@
   "codeRepository": "https://github.com/ohdsi-studies/PioneerWatchfulWaiting",
   "issueTracker": "https://github.com/ohdsi-studies/PioneerWatchfulWaiting/issues",
   "license": "https://spdx.org/licenses/Apache-2.0",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",


### PR DESCRIPTION
This bumps sFTP root folder to Task5 and codemeta.json version.
@keesvanbochove Is there version information elsewhere that should be bumped?