### PR TITLE
Fix negative cohort periods

### DIFF
--- a/inst/sql/sql_server/103.sql
+++ b/inst/sql/sql_server/103.sql
@@ -190,7 +190,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, DATEADD(day,180,C.condition_start_date) as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -212,7 +212,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, DATEADD(day,180,start_date) AS start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (

--- a/inst/sql/sql_server/103.sql
+++ b/inst/sql/sql_server/103.sql
@@ -190,7 +190,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -212,7 +212,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, DATEADD(day,180,start_date) AS start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (
@@ -1138,7 +1138,7 @@ group by person_id, end_date
 
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-select @target_cohort_id as cohort_definition_id, person_id, DATEADD(day,180,start_date) as start_date, end_date 
+select @target_cohort_id as cohort_definition_id, person_id, start_date, end_date 
 FROM #final_cohort CO
 ;
 

--- a/inst/sql/sql_server/104.sql
+++ b/inst/sql/sql_server/104.sql
@@ -200,7 +200,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -222,7 +222,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, DATEADD(day,180,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (
@@ -1193,7 +1193,7 @@ group by person_id, end_date
 
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-select @target_cohort_id as cohort_definition_id, person_id, DATEADD(day,180,start_date) as start_date, end_date 
+select @target_cohort_id as cohort_definition_id, person_id, start_date, end_date 
 FROM #final_cohort CO
 ;
 

--- a/inst/sql/sql_server/104.sql
+++ b/inst/sql/sql_server/104.sql
@@ -200,7 +200,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, DATEADD(day,180,C.condition_start_date) as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -222,7 +222,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, DATEADD(day,180,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (

--- a/inst/sql/sql_server/105.sql
+++ b/inst/sql/sql_server/105.sql
@@ -229,7 +229,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -251,7 +251,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, DATEADD(day,180,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (
@@ -1363,7 +1363,7 @@ group by person_id, end_date
 
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-select @target_cohort_id as cohort_definition_id, person_id, DATEADD(day,180,start_date) as start_date, end_date 
+select @target_cohort_id as cohort_definition_id, person_id, start_date, end_date 
 FROM #final_cohort CO
 ;
 

--- a/inst/sql/sql_server/105.sql
+++ b/inst/sql/sql_server/105.sql
@@ -229,7 +229,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, DATEADD(day,180,C.condition_start_date) as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -251,7 +251,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, DATEADD(day,180,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (

--- a/inst/sql/sql_server/106.sql
+++ b/inst/sql/sql_server/106.sql
@@ -228,7 +228,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, DATEADD(day,180,C.condition_start_date) as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -250,7 +250,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, DATEADD(day,180,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (

--- a/inst/sql/sql_server/106.sql
+++ b/inst/sql/sql_server/106.sql
@@ -228,7 +228,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -250,7 +250,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, DATEADD(day,180,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (
@@ -1410,7 +1410,7 @@ group by person_id, end_date
 
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-select @target_cohort_id as cohort_definition_id, person_id,DATEADD(day,180,start_date) as start_date, end_date 
+select @target_cohort_id as cohort_definition_id, person_id, start_date, end_date 
 FROM #final_cohort CO
 ;
 

--- a/inst/sql/sql_server/107.sql
+++ b/inst/sql/sql_server/107.sql
@@ -233,7 +233,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,548,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -255,7 +255,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, DATEADD(day,548,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (
@@ -1620,7 +1620,7 @@ group by person_id, end_date
 
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-select @target_cohort_id as cohort_definition_id, person_id,DATEADD(day,548,start_date) as start_date, end_date 
+select @target_cohort_id as cohort_definition_id, person_id, start_date, end_date 
 FROM #final_cohort CO
 ;
 

--- a/inst/sql/sql_server/107.sql
+++ b/inst/sql/sql_server/107.sql
@@ -233,7 +233,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,548,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, DATEADD(day,548,C.condition_start_date) as start_date, COALESCE(C.condition_end_date, DATEADD(day,548,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -255,7 +255,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, DATEADD(day,548,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (

--- a/inst/sql/sql_server/108.sql
+++ b/inst/sql/sql_server/108.sql
@@ -233,7 +233,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,548,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -255,7 +255,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, DATEADD(day,548,start_date) start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (
@@ -1668,7 +1668,7 @@ group by person_id, end_date
 
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-select @target_cohort_id as cohort_definition_id, person_id, DATEADD(day,548,start_date) as start_date, end_date 
+select @target_cohort_id as cohort_definition_id, person_id, as start_date, end_date 
 FROM #final_cohort CO
 ;
 

--- a/inst/sql/sql_server/108.sql
+++ b/inst/sql/sql_server/108.sql
@@ -233,7 +233,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,548,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, DATEADD(day,548,C.condition_start_date) as start_date, COALESCE(C.condition_end_date, DATEADD(day,548,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -255,7 +255,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, DATEADD(day,548,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (

--- a/inst/sql/sql_server/108.sql
+++ b/inst/sql/sql_server/108.sql
@@ -255,7 +255,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, DATEADD(day,548,start_date) start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, DATEADD(day,548,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (
@@ -1668,7 +1668,7 @@ group by person_id, end_date
 
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-select @target_cohort_id as cohort_definition_id, person_id, as start_date, end_date 
+select @target_cohort_id as cohort_definition_id, person_id, start_date, end_date 
 FROM #final_cohort CO
 ;
 

--- a/inst/sql/sql_server/109.sql
+++ b/inst/sql/sql_server/109.sql
@@ -222,7 +222,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,548,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, DATEADD(day,548,C.condition_start_date) as start_date, COALESCE(C.condition_end_date, DATEADD(day,548,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -244,7 +244,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, DATEADD(day,548,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (

--- a/inst/sql/sql_server/109.sql
+++ b/inst/sql/sql_server/109.sql
@@ -222,7 +222,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,548,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -244,7 +244,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, DATEADD(day,548,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (
@@ -1618,7 +1618,7 @@ group by person_id, end_date
 
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-select @target_cohort_id as cohort_definition_id, person_id, DATEADD(day,548,start_date) as start_date, end_date 
+select @target_cohort_id as cohort_definition_id, person_id, start_date, end_date 
 FROM #final_cohort CO
 ;
 

--- a/inst/sql/sql_server/110.sql
+++ b/inst/sql/sql_server/110.sql
@@ -222,7 +222,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,548,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, DATEADD(day,548,C.condition_start_date) as start_date, COALESCE(C.condition_end_date, DATEADD(day,548,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -244,7 +244,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, DATEADD(day,548,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (

--- a/inst/sql/sql_server/110.sql
+++ b/inst/sql/sql_server/110.sql
@@ -222,7 +222,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,548,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -244,7 +244,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, DATEADD(day,548,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (
@@ -1667,7 +1667,7 @@ group by person_id, end_date
 
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-select @target_cohort_id as cohort_definition_id, person_id,DATEADD(day,548,start_date) as start_date, end_date 
+select @target_cohort_id as cohort_definition_id, person_id, start_date, end_date 
 FROM #final_cohort CO
 ;
 

--- a/inst/sql/sql_server/111.sql
+++ b/inst/sql/sql_server/111.sql
@@ -200,7 +200,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -222,7 +222,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, DATEADD(day,180,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (
@@ -1149,7 +1149,7 @@ group by person_id, end_date
 
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-select @target_cohort_id as cohort_definition_id, person_id,DATEADD(day,180,start_date) as start_date, end_date 
+select @target_cohort_id as cohort_definition_id, person_id, start_date, end_date 
 FROM #final_cohort CO
 ;
 

--- a/inst/sql/sql_server/111.sql
+++ b/inst/sql/sql_server/111.sql
@@ -200,7 +200,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, DATEADD(day,180,C.condition_start_date) as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -222,7 +222,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, DATEADD(day,180,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (

--- a/inst/sql/sql_server/112.sql
+++ b/inst/sql/sql_server/112.sql
@@ -200,7 +200,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, DATEADD(day,180,C.condition_start_date) as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -222,7 +222,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, DATEADD(day,180,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (

--- a/inst/sql/sql_server/112.sql
+++ b/inst/sql/sql_server/112.sql
@@ -200,7 +200,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,180,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -222,7 +222,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, DATEADD(day,180,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (
@@ -1202,7 +1202,7 @@ group by person_id, end_date
 
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-select @target_cohort_id as cohort_definition_id, person_id, DATEADD(day,180,start_date) as start_date, end_date 
+select @target_cohort_id as cohort_definition_id, person_id, start_date, end_date 
 FROM #final_cohort CO
 ;
 

--- a/inst/sql/sql_server/341.sql
+++ b/inst/sql/sql_server/341.sql
@@ -200,7 +200,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,270,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, DATEADD(day,270,C.condition_start_date) as start_date, COALESCE(C.condition_end_date, DATEADD(day,270,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -222,7 +222,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, DATEADD(day,270,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (

--- a/inst/sql/sql_server/341.sql
+++ b/inst/sql/sql_server/341.sql
@@ -200,7 +200,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,270,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -222,7 +222,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, DATEADD(day,270,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (
@@ -1201,7 +1201,7 @@ group by person_id, end_date
 
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-select @target_cohort_id as cohort_definition_id, person_id, DATEADD(day,270,start_date) as start_date, end_date 
+select @target_cohort_id as cohort_definition_id, person_id, start_date, end_date 
 FROM #final_cohort CO
 ;
 

--- a/inst/sql/sql_server/342.sql
+++ b/inst/sql/sql_server/342.sql
@@ -200,7 +200,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,365,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -222,7 +222,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, DATEADD(day,365,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (
@@ -1201,7 +1201,7 @@ group by person_id, end_date
 
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-select @target_cohort_id as cohort_definition_id, person_id, DATEADD(day,365,start_date) as start_date, end_date 
+select @target_cohort_id as cohort_definition_id, person_id, start_date, end_date 
 FROM #final_cohort CO
 ;
 

--- a/inst/sql/sql_server/342.sql
+++ b/inst/sql/sql_server/342.sql
@@ -200,7 +200,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,365,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, DATEADD(day,365,C.condition_start_date) as start_date, COALESCE(C.condition_end_date, DATEADD(day,365,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -222,7 +222,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, DATEADD(day,365,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (

--- a/inst/sql/sql_server/343.sql
+++ b/inst/sql/sql_server/343.sql
@@ -200,7 +200,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,548,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, DATEADD(day,548,C.condition_start_date) as start_date, COALESCE(C.condition_end_date, DATEADD(day,548,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -222,7 +222,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, DATEADD(day,548,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (

--- a/inst/sql/sql_server/343.sql
+++ b/inst/sql/sql_server/343.sql
@@ -200,7 +200,7 @@ FROM
   FROM 
   (
   -- Begin Condition Occurrence Criteria
-SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,1,C.condition_start_date)) as end_date,
+SELECT C.person_id, C.condition_occurrence_id as event_id, C.condition_start_date as start_date, COALESCE(C.condition_end_date, DATEADD(day,548,C.condition_start_date)) as end_date,
        C.CONDITION_CONCEPT_ID as TARGET_CONCEPT_ID, C.visit_occurrence_id,
        C.condition_start_date as sort_date
 FROM 
@@ -222,7 +222,7 @@ WHERE P.ordinal = 1
 -- End Primary Events
 
 )
-SELECT event_id, person_id, start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
+SELECT event_id, person_id, DATEADD(day,548,start_date) as start_date, end_date, op_start_date, op_end_date, visit_occurrence_id
 INTO #qualified_events
 FROM 
 (
@@ -1201,7 +1201,7 @@ group by person_id, end_date
 
 DELETE FROM @target_database_schema.@target_cohort_table where cohort_definition_id = @target_cohort_id;
 INSERT INTO @target_database_schema.@target_cohort_table (cohort_definition_id, subject_id, cohort_start_date, cohort_end_date)
-select @target_cohort_id as cohort_definition_id, person_id, DATEADD(day,548,start_date) as start_date, end_date 
+select @target_cohort_id as cohort_definition_id, person_id, start_date, end_date 
 FROM #final_cohort CO
 ;
 


### PR DESCRIPTION
Fixes #84 

Better fix than proposed in #86, as this applies the offset index date at the beginning and the rest of the cohort sql definition uses this new date. Inclusion criteria and censoring events should be all relative to the offset index date.